### PR TITLE
Fix bug with polling logic

### DIFF
--- a/Sample Code/SampleApp/AuthnAPI/PingAuthenticationCore/CoreLogicLayer.swift
+++ b/Sample Code/SampleApp/AuthnAPI/PingAuthenticationCore/CoreLogicLayer.swift
@@ -261,9 +261,8 @@ final class CoreLogicLayer : NSObject {
             }
             
             stopPolling()
-        }
-        
-        if let flowId = requestParams.flowId {
+            
+        } else if let flowId = requestParams.flowId {
             let pollRequestParams = RequestParams.init(flowID: flowId)
             pollRequestParams.name = Identifiers.PathNamePoll
             


### PR DESCRIPTION
It's possible to get stuck in a polling loop if the timer reaches the maximum limit and the flowID is still valid then it would continue polling, then the timer would start at 1.